### PR TITLE
Fix some layout and typography issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,10 +53,10 @@
       .site-selector .note {
         color: black;
         margin-top: .5rem;
-        font-size: small;
       }
       .site-selector a {
         text-decoration: none;
+        font-size: 90%;
       }
       .about {
         text-align: center;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
     <style>
       body {
         background: #fff;
-        font-family: 'Trebuchet MS', sans-serif;
+        font-family: Helvetica, sans-serif;
+        font-size: 18px;
+        line-height: 1.15;
       }
       .site-selector {
         display: flex;

--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
         display: inline-block;
         font-weight: bold;
         padding: .7em;
-        white-space: nowrap;
       }
       .site-selector .note {
         color: black;

--- a/index.html
+++ b/index.html
@@ -18,17 +18,21 @@
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: center;
-        padding: 2rem;
+        padding: 0;
+        gap: 2.5rem;
         text-align: center;
+
+        /*
+        Bottom margin serves to prevent footer about text
+        from seeming as if it was part of the last site in list
+        on narrow viewports.
+        */
+        margin: 0 0 5rem 0;
       }
       .site-selector li {
         display: flex;
         flex-direction: column;
-        margin: 5rem 2.5rem;
-      }
-      .site-selector .img-wrapper {
-        position: relative;
-        text-align: center;
+        width: 15rem;
       }
       .img-wrapper img {
         width: 15rem;
@@ -55,10 +59,21 @@
       .about {
         text-align: center;
         display: block;
+        margin: 2.5rem;
       }
-      .about p {
-        width: 45rem;
-        display: inline-block;
+
+      @media screen and (min-width: 800px) {
+        body {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          flex-flow: column nowrap;
+          justify-content: space-between;
+        }
+        .about {
+          max-width: 60vw;
+          margin: 0 auto;
+        }
       }
     </style>
 

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
   <body>
     <div class="about">
-      <p>Geolexica: Open geospatial terminology<p>
+      <p>Geolexica: Open&nbsp;geospatial&nbsp;terminology<p>
     </div>
     <ul class="site-selector">
       <li>
@@ -135,10 +135,10 @@
 
     <div class="about">
     <p>
-		The name "`geolexica`" is a combination of the Greek prefix "`geo-`"
-		(of and pertaining to the Earth) and the suffix "`lexica`"
-		derived from the Greek "`lexiko`", counterpart of the English
-		"`lexicon`" (vocabulary).
+      The name “Geolexica” is&nbsp;a&nbsp;combination of&nbsp;the&nbsp;Greek&nbsp;prefix “geo-”
+      (of&nbsp;and&nbsp;pertaining to&nbsp;the&nbsp;Earth) and&nbsp;the&nbsp;suffix “lexica”
+      derived from the&nbsp;Greek “lexiko”, counterpart of&nbsp;the&nbsp;English
+      “lexicon” (vocabulary).
     </p>
     </div>
 


### PR DESCRIPTION
- Layout is responsive & suitable for narrower/mobile viewports
- It’s a bit more even on wider viewports as well
- Font size / line height measurements made consistent with actual Geolexica instances
- Corrections to typography and to avoid awkward line breaks

Before:

<img width="1555" alt="geolexica-before" src="https://github.com/geolexica/geolexica.org/assets/292959/66d74ae7-d8c6-4614-86c9-17738cf4d4b9">

After:

<img width="1555" alt="geolexica-after" src="https://github.com/geolexica/geolexica.org/assets/292959/111930a4-ffba-478f-8953-f619e488a09d">
