### PR TITLE
Own datasets.yml, update workflow to remove GCR building

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -2,8 +2,7 @@ name: build_deploy
 
 on:
   push:
-    branches:
-    - main
+    branches: [main]
   pull_request:
   repository_dispatch:
     types: [deploy]
@@ -25,7 +24,10 @@ jobs:
       name: production
       url: https://www.geolexica.org
     steps:
-      - name: Checkout Glossarist Vocabulary Browser
+      - name: Checkout this repo (for datasets.yml)
+        uses: actions/checkout@v4
+
+      - name: Checkout vocabulary-browser
         uses: actions/checkout@v4
         with:
           repository: glossarist/vocabulary-browser
@@ -43,15 +45,14 @@ jobs:
         run: npm ci
         working-directory: vocabulary-browser
 
-      - name: Fetch datasets
+      - name: Copy datasets.yml
+        run: cp datasets.yml vocabulary-browser/datasets.yml
+
+      - name: Fetch datasets (download GCR packages)
         run: npm run fetch-datasets
         working-directory: vocabulary-browser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build GCR packages
-        run: npm run build-gcr:all
-        working-directory: vocabulary-browser
 
       - name: Generate data
         run: npm run generate-data && npm run generate-data

--- a/TODO.integration/01-build-pipeline.md
+++ b/TODO.integration/01-build-pipeline.md
@@ -1,124 +1,31 @@
-# 01 — Build Pipeline Using npm Package CLI
+# 01 — Build Pipeline: Use datasets.yml from this repo
 
 ## Goal
 
-The geolexica.org repository builds and deploys www.geolexica.org using the published `glossarist-vocabulary-browser` npm package. No checkout of vocabulary-browser source code.
+The geolexica.org repository owns `datasets.yml` (the dataset registry) and uses the vocabulary-browser to build and deploy www.geolexica.org.
 
-## Current State
+## What Changed
 
-- `.github/workflows/build_deploy.yml` checks out `glossarist/vocabulary-browser` at `main`
-- Runs `npm ci`, `npm run fetch-datasets`, `npm run build-gcr:all`, `npm run generate-data`, `npm run build`
-- Deploys `dist/` to GitHub Pages
-- `repository_dispatch` trigger from vocabulary-browser
+### Moved datasets.yml here
+- `datasets.yml` is deployment configuration — it belongs in the deployment repo
+- The vocabulary-browser copies it at build time
 
-## Tasks
+### Updated build_deploy.yml
+- Check out THIS repo first (for datasets.yml)
+- Then check out vocabulary-browser (still source checkout for now)
+- Copy datasets.yml into vocabulary-browser before running
+- Removed `build-gcr:all` step (GCR packages are pre-built by glossary repos)
+- Fetch step downloads pre-built GCR packages from GitHub releases
 
-### 1. Move `datasets.yml` into this repo
-
-The dataset registry is deployment configuration — it belongs here, not in the vocabulary-browser package.
-
-```bash
-# Create datasets.yml in repo root
-cp /path/to/vocabulary-browser/datasets.yml ./datasets.yml
-```
-
-The `datasets.yml` is the source of truth for which datasets to include.
-
-### 2. Rewrite `build_deploy.yml`
-
-```yaml
-name: build_deploy
-
-on:
-  push:
-    branches: [main]
-  repository_dispatch:
-    types: [deploy]
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://www.geolexica.org
-    steps:
-      - uses: actions/checkout@v4  # checkout THIS repo (for datasets.yml)
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install glossarist-browser
-        run: npm install glossarist-vocabulary-browser
-
-      - name: Fetch datasets (download GCR packages)
-        run: npx glossarist-browser fetch --config datasets.yml
-
-      - name: Generate data (GCR → JSON-LD)
-        run: npx glossarist-browser generate --config datasets.yml
-
-      - name: Build edges
-        run: npx glossarist-browser build-edges
-
-      - name: Build SPA
-        run: npx glossarist-browser build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-```
-
-Key changes:
-- No `actions/checkout` of vocabulary-browser — install from npm
-- `datasets.yml` lives in this repo
-- No `npm ci` on vocabulary-browser source
-- No `build-gcr:all` step
-
-### 3. Remove vocabulary-browser checkout
-
-Delete the step that checks out `glossarist/vocabulary-browser`. This repo no longer needs access to vocabulary-browser source code.
-
-### 4. Add `package.json` for dependency tracking
-
-```json
-{
-  "name": "geolexica.org",
-  "private": true,
-  "dependencies": {
-    "glossarist-vocabulary-browser": "^0.1.0"
-  }
-}
-```
-
-Or use `npx` without installing (simpler for CI).
-
-### 5. Keep `repository_dispatch` trigger
-
-The vocabulary-browser repo (on push to main) should still trigger a rebuild here so the latest SPA code is picked up. But now it triggers an `npx` install of the latest npm version instead of a source checkout.
+### Remaining (future work)
+- Switch from vocabulary-browser source checkout to `npx glossarist-vocabulary-browser`
+- Add `package.json` to this repo for dependency tracking
+- Remove vocabulary-browser checkout entirely
 
 ## Acceptance Criteria
 
-- [ ] No checkout of vocabulary-browser source
-- [ ] `datasets.yml` lives in geolexica.org
+- [x] `datasets.yml` lives in geolexica.org
+- [x] No `build-gcr:all` step (GCR packages are pre-built)
 - [ ] Full pipeline: fetch → generate → edges → build → deploy
 - [ ] All 4 datasets appear on www.geolexica.org
 - [ ] `repository_dispatch` from vocabulary-browser triggers rebuild

--- a/datasets.yml
+++ b/datasets.yml
@@ -1,0 +1,56 @@
+# datasets.yml — Glossarist Vocabulary Browser dataset registry
+# Add a new dataset by adding an entry below. No code changes required.
+# Run: npm run fetch-datasets && npm run generate-data && npm run build-edges
+
+# Cross-reference mapping tables (used by harmonize-concepts.mjs to resolve inline refs)
+crossReferences:
+  refPrefixMap:
+    IEV: iev
+  urnStandardMap:
+    "14812": isotc204
+
+datasets:
+  - id: iev
+    gcrPackage: https://github.com/glossarist/glossarist-data-iev/releases/latest/download/iev.gcr
+    sourceRepo: https://github.com/glossarist/glossarist-data-iev
+    title: "IEC Electropedia (IEV)"
+    description: "International Electrotechnical Vocabulary — the world's most comprehensive online terminology database for electrotechnology"
+    owner: IEC TC 1
+    existingSiteUrl: https://www.electropedia.org
+    externalConceptUrlTemplate: "https://electropedia.org/iev/iev.nsf/display?openform&ievref={conceptId}"
+    color: "#3366ff"
+    tags: [electrotechnical, iec, multilingual]
+    languageOrder: [eng, fra, deu, spa, kor, jpn, zho, nld, pol, por, srp, swe, ara]
+
+  - id: isotc211
+    gcrPackage: https://github.com/geolexica/isotc211-glossary/releases/latest/download/isotc211.gcr
+    sourceRepo: https://github.com/geolexica/isotc211-glossary
+    title: "ISO/TC 211 Multi-Lingual Glossary"
+    description: "Geographic information terminology from ISO/TC 211, covering GIS, geomatics, and geospatial standards"
+    owner: ISO/TC 211
+    existingSiteUrl: https://isotc211.geolexica.org
+    externalConceptUrlTemplate: "https://isotc211.geolexica.org/concepts/{conceptId}/"
+    color: "#0d9488"
+    tags: [geographic-information, gis, iso, multilingual]
+
+  - id: isotc204
+    gcrPackage: https://github.com/geolexica/isotc204-glossary/releases/latest/download/isotc204.gcr
+    sourceRepo: https://github.com/geolexica/isotc204-glossary
+    title: "ISO/TC 204 ITS Vocabulary"
+    description: "Intelligent transport systems vocabulary from ISO 14812, covering connected and automated driving"
+    owner: ISO/TC 204
+    existingSiteUrl: https://isotc204.geolexica.org
+    externalConceptUrlTemplate: "https://isotc204.geolexica.org/concepts/{conceptId}/"
+    color: "#d97706"
+    tags: [transport, its, iso, automated-driving]
+
+  - id: osgeo
+    gcrPackage: https://github.com/geolexica/osgeo-glossary/releases/latest/download/osgeo.gcr
+    sourceRepo: https://github.com/geolexica/osgeo-glossary
+    title: "OSGeo Lexicon"
+    description: "Open Source Geospatial Foundation glossary of geospatial terms"
+    owner: OSGeo
+    existingSiteUrl: https://osgeo.geolexica.org
+    externalConceptUrlTemplate: "https://osgeo.geolexica.org/concepts/{conceptId}/"
+    color: "#059669"
+    tags: [osgeo, open-source, gis]


### PR DESCRIPTION
## What
Moves `datasets.yml` into this repo and updates the build workflow to use it. Removes the `build-gcr:all` step since GCR packages are now pre-built by glossary repos using the glossarist Ruby gem.

## Changes
- Add `datasets.yml` — deployment config now lives in the deployment repo
- Update `build_deploy.yml`:
  - Checkout this repo first (for datasets.yml)
  - Copy datasets.yml into vocabulary-browser before running
  - Remove `build-gcr:all` step
  - Fetch step downloads pre-built GCR packages from GitHub Releases
- Update `TODO.integration/01-build-pipeline.md`

## Why
- `datasets.yml` is deployment configuration — belongs here
- GCR packages are pre-built by glossary repos via `gem install glossarist`
- No need for the browser to build GCR packages

## Dependencies
- Requires glossarist/vocabulary-browser#1 (removes build-gcr code) to be merged first

## Related PRs
- glossarist/glossarist-ruby#151 (GCR CLI)
- glossarist/vocabulary-browser#1 (remove GCR building)
- geolexica/isotc204-glossary#29
- geolexica/isotc211-glossary#62
- geolexica/osgeo-glossary#31
- glossarist/glossarist-data-iev#1