### PR TITLE
chore: bump CI Node to 24

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: vocabulary-browser/package-lock.json
 


### PR DESCRIPTION
## Summary

Bumps CI Node from 20 to 24 in `build_deploy.yml`.

## Why

concept-browser v0.7.45+ requires Node 24/npm 11 for:
1. Correct esbuild optional-dependency handling (npm 10 fails with EBADPLATFORM on linux-x64 trying to install @esbuild/aix-ppc64)
2. Newer ESM syntax in scripts/generate-data.mjs (top-level await inside async function)

Without this bump, the deploy workflow fails at the `npm ci` step in the vocabulary-browser checkout.

## Test

- concept-browser CI uses Node 24 successfully for the same pipeline.
- Other geolexica sites (isotc204, isotc211, osgeo) have parallel PRs applying the same bump.
